### PR TITLE
Small bugfix,support for the SSH api functions, new droplet updates

### DIFF
--- a/digitalocean.class.php
+++ b/digitalocean.class.php
@@ -186,7 +186,9 @@ class digitalOcean
 
 	public function destroyDroplet($dropletId)
 	{
-		return self::request('/droplets/' . $dropletId . '/destroy');
+        // This is forced on, because there is no good reason to not have this.
+        $parameters = array("scrub_data" => true);
+		return self::request('/droplets/' . $dropletId . '/destroy', $parameters);
 	}
 
 	public function validateDroplet($dropletId)
@@ -341,4 +343,12 @@ class digitalOcean
         return self::request('/ssh_keys/' . $id . '/destroy');
     }    
          
+         
+    /**
+    * Events
+    */
+    
+    public function checkoutEvent($id) {
+        return self::request('/events/' . $id);
+    }         
 } 


### PR DESCRIPTION
Fix for $parameters warning if images() is called without a filter.
Addition of all the SSH key management functions.
Addition of the event API.

scrub_data also turned on by default now. This seems like a monstrous issue from DO's side that it's not always on but without it other clients can read your data at a later stage. I didn't allow for it to be unset because I see no point as you cannot predictably get back your section of the disk.

Tried to stick in line with your naming and coding style. We're using this for a new project at Snapt.
